### PR TITLE
ci(publication): Use java 11 and node 16 for builds and publications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
           server-id: jfrog-flock-community
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16'
       - name: Publish react to jfrog packages
         run: |
           npm ci


### PR DESCRIPTION
Small minor change to line up java / node versions used in github actions