### PR TITLE
Add Ory Kratos as OauthProvider

### DIFF
--- a/eco-feature/eco-feature-user/src/main/kotlin/model/UserAccountOauthProvider.kt
+++ b/eco-feature/eco-feature-user/src/main/kotlin/model/UserAccountOauthProvider.kt
@@ -3,5 +3,6 @@ package community.flock.eco.feature.user.model
 enum class UserAccountOauthProvider(name: String) {
     GOOGLE("google"),
     FACEBOOK("facebook"),
-    GITHUB("github")
+    GITHUB("github"),
+    KRATOS("kratos")
 }


### PR DESCRIPTION
Let's support Kratos as an OauthProvider 

See https://www.ory.sh/docs/kratos/ory-kratos-intro for more details

(Workday is currently doing an initiali implementation with the Ory stack. At one point that could potentially move here.